### PR TITLE
feat(abc): add form-simple-input-submit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# Windows reserved device names accidentally written to disk
+nul
+
+# OS / editor cruft
+.DS_Store
+Thumbs.db
+*.swp
+.idea/
+.vscode/

--- a/abc/general/form-simple-input-submit/README.md
+++ b/abc/general/form-simple-input-submit/README.md
@@ -1,0 +1,59 @@
+# 简单输入表单 ABC
+
+> `form-simple-input-submit` · category: `form` · industry: `general`
+
+一个最小可运行的表单 Module：标题 + 输入框 + 提交/取消按钮，对外暴露输入值与提交/取消事件。作为 **AMT2ABC 仓库的第一个标杆范例**，演示完整的脱敏与入库流程。
+
+## 接口契约
+
+### Inputs
+
+| 名称 | 类型 | 说明 | 默认值 |
+|------|------|------|--------|
+| `title` | string | 表单标题文字 | `请输入信息` |
+| `placeholder` | string | 输入框占位符 | `在此输入...` |
+| `defaultValue` | string | 输入框默认值 | `""` |
+
+### Outputs
+
+| 名称 | 类型 | 说明 |
+|------|------|------|
+| `inputValue` | string | 当前输入框的值（提交后更新） |
+| `isSubmitted` | boolean | 是否已点击提交 |
+
+### Methods
+
+| 名称 | 说明 |
+|------|------|
+| `clear()` | 清空输入框并重置提交状态 |
+
+### Events
+
+| 名称 | 说明 |
+|------|------|
+| `onSubmit` | 点击提交按钮时触发（`inputValue` 已更新） |
+| `onCancel` | 点击取消按钮时触发 |
+
+## 脱敏记录
+
+本 ABC 已完成脱敏（`amt2abc.sanitized = true`），处理项：
+
+| 检查点 | 原始值 | 脱敏后 | 依据 |
+|--------|--------|--------|------|
+| `applicationInfo.name` | `test1` | `simple-input-form` | 5.2 语义化命名 |
+| `applicationInfo.id` | `6a3a1884a4c46a7c40616a75` | `000000000000000000000000` | 5.2 重新生成，去除内部库关联 |
+| `applicationInfo.createAt` | `1749000000000` | `0` | 去除时间戳痕迹 |
+| `applicationInfo.createBy` | `""` | `""`（已为空） | 无敏感信息 |
+
+> 其余字段（`inputs/outputs/methods/event/global/ui/i18n`）经审查均为通用业务内容，无客户、产线、设备、内网地址等敏感信息。
+
+## 用法示例
+
+见 `examples/` 目录：
+
+- `examples/inputs.json` — 一组典型入参
+- `examples/outputs.json` — 对应输出
+
+## 来源
+
+内部通用组件（已脱敏）。License: Apache-2.0。

--- a/abc/general/form-simple-input-submit/abc.json
+++ b/abc/general/form-simple-input-submit/abc.json
@@ -1,0 +1,454 @@
+{
+  "amt2abc": {
+    "id": "form-simple-input-submit",
+    "name": "简单输入表单 ABC",
+    "industry": "general",
+    "category": "form",
+    "author": "zylliondata",
+    "sanitized": true
+  },
+  "applicationInfo": {
+    "name": "simple-input-form",
+    "type": "module",
+    "id": "000000000000000000000000",
+    "createBy": "",
+    "createAt": 0,
+    "publicToAll": false,
+    "publicToMarketplace": false
+  },
+  "applicationDSL": {
+    "outputs": [
+      {
+        "name": "inputValue",
+        "description": "当前输入框的值（提交后更新）",
+        "value": "{{ cv_inputValue.value }}"
+      },
+      {
+        "name": "isSubmitted",
+        "description": "是否已点击提交",
+        "value": "{{ cv_submitted.value === 'yes' }}"
+      }
+    ],
+    "ui": [
+      {
+        "hidden": false,
+        "slot": "default",
+        "customId": "",
+        "contextObject": {},
+        "compType": "rect",
+        "children": [
+          {
+            "hidden": false,
+            "lineClamp": 0,
+            "slot": "default",
+            "customId": "",
+            "contextObject": {},
+            "parentId": "root-rect-0001",
+            "compType": "text",
+            "onEvent": [],
+            "valueType": "text",
+            "name": "formTitle",
+            "x": 20,
+            "width": 460,
+            "customClass": "",
+            "y": 16,
+            "style": {
+              "transform": "translate(20px, 16px)",
+              "backgroundColor": "transparent",
+              "color": "#1F2937",
+              "width": "460px",
+              "fontSize": "24px",
+              "position": "absolute",
+              "fontWeight": "600",
+              "height": "40px"
+            },
+            "id": "title-text-0002",
+            "ignorePrint": false,
+            "locked": false,
+            "value": "{{ title.value }}",
+            "height": 40
+          },
+          {
+            "regexp": "",
+            "hidden": false,
+            "defaultValue": "{{ defaultValue.value }}",
+            "suffixIcon": "",
+            "labelWidth": "100px",
+            "slot": "default",
+            "customId": "",
+            "contextObject": {},
+            "required": false,
+            "prefixIconClickable": false,
+            "suffixIconClickable": false,
+            "feedback": "",
+            "showCount": false,
+            "compType": "input",
+            "readonly": false,
+            "labelTooltip": "",
+            "labelStyle": {
+              "fontSize": "26px"
+            },
+            "regexpMessage": "",
+            "disabled": false,
+            "id": "main-input-0003",
+            "ignorePrint": false,
+            "placeholder": "{{ placeholder.value }}",
+            "locked": false,
+            "height": 48,
+            "clearable": true,
+            "textType": "text",
+            "label": "",
+            "parentId": "root-rect-0001",
+            "labelPlacement": "left",
+            "labelAlign": "left",
+            "onEvent": [
+              {
+                "handler": {
+                  "comp": {
+                    "name": "cv_inputValue",
+                    "methodName": "setValue",
+                    "params": {
+                      "comp": "{{ userInput.value }}",
+                      "path": ""
+                    }
+                  },
+                  "compType": "setTempState",
+                  "delay": "",
+                  "conditions": [
+                    {
+                      "type": "and",
+                      "value": "true"
+                    }
+                  ],
+                  "sync": true
+                },
+                "name": "change",
+                "id": "evt-input-change-000a"
+              }
+            ],
+            "name": "userInput",
+            "x": 20,
+            "width": 460,
+            "customClass": "",
+            "inputStyle": {
+              "fontSize": "18px"
+            },
+            "y": 72,
+            "style": {
+              "transform": "translate(20px, 72px)",
+              "width": "460px",
+              "position": "absolute",
+              "height": "48px"
+            },
+            "prefixIcon": "",
+            "min": null,
+            "max": null
+          },
+          {
+            "strong": false,
+            "prefixIconColor": "",
+            "hidden": false,
+            "tooltip": "",
+            "suffixIcon": "",
+            "slot": "default",
+            "type": "primary",
+            "customId": "",
+            "contextObject": {},
+            "compType": "button",
+            "corner": "default",
+            "disabled": false,
+            "id": "submit-btn-0004",
+            "ignorePrint": false,
+            "text": "提交",
+            "locked": false,
+            "height": 44,
+            "loading": false,
+            "parentId": "root-rect-0001",
+            "suffixIconColor": "",
+            "appearance": "primary",
+            "onEvent": [
+              {
+                "handler": {
+                  "comp": {
+                    "name": "cv_submitted",
+                    "methodName": "setValue",
+                    "params": {
+                      "comp": "yes",
+                      "path": ""
+                    }
+                  },
+                  "compType": "setTempState",
+                  "delay": "",
+                  "conditions": [
+                    {
+                      "type": "and",
+                      "value": "true"
+                    }
+                  ],
+                  "sync": true
+                },
+                "name": "click",
+                "id": "evt-submit-click-000b"
+              },
+              {
+                "handler": {
+                  "comp": {
+                    "name": "cv_inputValue",
+                    "methodName": "setValue",
+                    "params": {
+                      "comp": "{{ userInput.value }}",
+                      "path": ""
+                    }
+                  },
+                  "compType": "setTempState",
+                  "delay": "",
+                  "conditions": [
+                    {
+                      "type": "and",
+                      "value": "true"
+                    }
+                  ],
+                  "sync": true
+                },
+                "name": "click",
+                "id": "evt-submit-trigger-000c"
+              },
+              {
+                "handler": {
+                  "comp": {
+                    "name": "onSubmit"
+                  },
+                  "compType": "triggerModuleEvent",
+                  "delay": "",
+                  "stopPropagation": true,
+                  "conditions": [
+                    {
+                      "type": "and",
+                      "value": "true"
+                    }
+                  ],
+                  "sync": false
+                },
+                "name": "click",
+                "id": "evt-submit-module-000d"
+              }
+            ],
+            "name": "submitBtn",
+            "x": 280,
+            "width": 96,
+            "customClass": "",
+            "y": 144,
+            "style": {
+              "transform": "translate(280px, 144px)",
+              "width": "96px",
+              "fontSize": "32px",
+              "position": "absolute",
+              "height": "44px"
+            },
+            "prefixIcon": ""
+          },
+          {
+            "strong": false,
+            "prefixIconColor": "",
+            "hidden": false,
+            "tooltip": "",
+            "suffixIcon": "",
+            "slot": "default",
+            "type": "default",
+            "customId": "",
+            "contextObject": {},
+            "compType": "button",
+            "corner": "default",
+            "disabled": false,
+            "id": "cancel-btn-0005",
+            "ignorePrint": false,
+            "text": "取消",
+            "locked": false,
+            "height": 44,
+            "loading": false,
+            "parentId": "root-rect-0001",
+            "suffixIconColor": "",
+            "appearance": "default",
+            "onEvent": [
+              {
+                "handler": {
+                  "comp": {
+                    "name": "onCancel"
+                  },
+                  "compType": "triggerModuleEvent",
+                  "delay": "",
+                  "stopPropagation": true,
+                  "conditions": [
+                    {
+                      "type": "and",
+                      "value": "true"
+                    }
+                  ],
+                  "sync": false
+                },
+                "name": "click",
+                "id": "evt-cancel-module-000e"
+              }
+            ],
+            "name": "cancelBtn",
+            "x": 384,
+            "width": 96,
+            "customClass": "",
+            "y": 144,
+            "style": {
+              "transform": "translate(384px, 144px)",
+              "width": "96px",
+              "fontSize": "32px",
+              "position": "absolute",
+              "height": "44px"
+            },
+            "prefixIcon": ""
+          }
+        ],
+        "onEvent": [],
+        "name": "formRoot",
+        "x": 0,
+        "width": 511,
+        "customClass": "",
+        "y": 0,
+        "style": {
+          "border": "1px solid #E5E7EB",
+          "transform": "translate(0px, 0px)",
+          "backgroundColor": "#FFFFFF",
+          "borderRadius": "8px",
+          "width": "511px",
+          "position": "absolute",
+          "height": "248px"
+        },
+        "id": "root-rect-0001",
+        "ignorePrint": false,
+        "locked": false,
+        "height": 248
+      }
+    ],
+    "customShortcuts": [],
+    "inputs": [
+      {
+        "defaultValue": "请输入信息",
+        "name": "title",
+        "description": "表单标题文字",
+        "type": "data",
+        "testValue": "请输入信息"
+      },
+      {
+        "defaultValue": "在此输入...",
+        "name": "placeholder",
+        "description": "输入框占位符",
+        "type": "data",
+        "testValue": "在此输入..."
+      },
+      {
+        "defaultValue": "",
+        "name": "defaultValue",
+        "description": "输入框默认值",
+        "type": "data",
+        "testValue": ""
+      }
+    ],
+    "methods": [
+      {
+        "name": "clear",
+        "description": "清空输入框并重置提交状态",
+        "action": {
+          "comp": {
+            "name": "userInput",
+            "methodName": "setValue",
+            "params": {
+              "comp": "",
+              "path": ""
+            }
+          },
+          "compType": "setTempState",
+          "delay": "",
+          "conditions": [
+            {
+              "type": "and",
+              "value": "true"
+            }
+          ],
+          "sync": true
+        },
+        "params": []
+      }
+    ],
+    "global": [
+      {
+        "name": "cv_inputValue",
+        "id": "var-input-value-0001",
+        "type": "variable",
+        "value": ""
+      },
+      {
+        "name": "cv_submitted",
+        "id": "var-submitted-0002",
+        "type": "variable",
+        "value": "no"
+      }
+    ],
+    "event": {
+      "enableEventTestMessage": false,
+      "list": [
+        {
+          "name": "onSubmit",
+          "description": "点击提交按钮时触发（inputValue 已更新）"
+        },
+        {
+          "name": "onCancel",
+          "description": "点击取消按钮时触发"
+        }
+      ]
+    },
+    "preload": {
+      "style": "",
+      "script": ""
+    },
+    "canvasSetting": {
+      "deviceType": "desktop",
+      "paddingX": 0,
+      "backgroundColor": "",
+      "backgroundImage": "",
+      "backgroundSize": "cover",
+      "backgroundPosition": "center center",
+      "backgroundRepeat": "no-repeat",
+      "backgroundOrigin": "center center",
+      "paddingY": 0
+    },
+    "i18n": {
+      "defaultLocale": "zh-CN",
+      "messages": {
+        "en-US": {
+          "ioap.hello_world": "Hello World",
+          "ioap.material.file_upload.trigger_by_camera": "Take Photo & Upload",
+          "ioap.material.file_upload.trigger_by_dnd.description1": "Click or drag files here to upload",
+          "ioap.material.file_upload.trigger_by_dnd.description2": "Do not upload sensitive data, such as bank card numbers, passwords, credit card numbers, expiration dates and security codes.",
+          "ioap.material.file_upload.trigger_by_local_file": "Upload File",
+          "ioap.resource.query.execution_failed": "Query Failed",
+          "ioap.resource.query.execution_successful": "Query Successful"
+        },
+        "zh-CN": {
+          "ioap.hello_world": "你好，世界",
+          "ioap.material.file_upload.trigger_by_camera": "拍照上传",
+          "ioap.material.file_upload.trigger_by_dnd.description1": "点击或者拖动文件到该区域来上传",
+          "ioap.material.file_upload.trigger_by_dnd.description2": "请不要上传敏感数据，比如你的银行卡号和密码，信用卡号有效期和安全码",
+          "ioap.material.file_upload.trigger_by_local_file": "上传文件",
+          "ioap.resource.query.execution_failed": "查询失败",
+          "ioap.resource.query.execution_successful": "查询成功"
+        }
+      },
+      "fallbackLocale": "zh-CN",
+      "source": {}
+    },
+    "setting": {
+      "iconCorner": "default",
+      "icon": "",
+      "iconColor": "",
+      "description": "简单表单 Module：标题+输入框+提交/取消，暴露 inputValue 输出与 onSubmit/onCancel 事件",
+      "category": []
+    }
+  }
+}

--- a/abc/general/form-simple-input-submit/examples/inputs.json
+++ b/abc/general/form-simple-input-submit/examples/inputs.json
@@ -1,0 +1,5 @@
+{
+  "title": "请输入设备编号",
+  "placeholder": "如 EQ-001",
+  "defaultValue": ""
+}

--- a/abc/general/form-simple-input-submit/examples/outputs.json
+++ b/abc/general/form-simple-input-submit/examples/outputs.json
@@ -1,0 +1,4 @@
+{
+  "inputValue": "EQ-001",
+  "isSubmitted": true
+}

--- a/docs/contribute-abc-quickstart.md
+++ b/docs/contribute-abc-quickstart.md
@@ -1,0 +1,146 @@
+# 贡献 ABC 快速指南
+
+> 没用过 GitHub 也没关系，照着这篇一步步来就行。
+
+## 你要做什么
+
+把一个你做的 ABC（脱敏后）提交到开源仓库。**一共 4 步**。
+
+---
+
+## 第 1 步：导出 ABC
+
+在平台里把 ABC 导出成一个 `.json` 文件。
+
+> 导出后先别急着提交，先做第 2 步。
+
+## 第 2 步：检查有没有敏感信息（最重要）
+
+打开 JSON 文件，搜索下面这些词，**有的话必须改掉或删掉**：
+
+| 找什么 | 改成 |
+|--------|------|
+| 客户名、公司名（如"某某汽车"） | `CustomerA` |
+| 设备型号、品牌 | `Machine` / `Device` |
+| IP 地址、内网地址（如 `10.x.x.x`） | `<endpoint>` |
+| 真实字段名（如 `dp1_temp_zk01`） | 语义化名字，如 `temperature` |
+| 真实人名、地名 | 删掉 |
+
+> [!tip] 不确定就先交
+> 你只要"尽量别放敏感信息"。**最终把关由维护者负责**，发现问题会打回来让你改，不会出事。
+
+## 第 3 步：在最前面加一段 `amt2abc` 头
+
+用编辑器打开你的 JSON，在**最外层的 `{` 后面**插入下面这段（改成你的信息）：
+
+```json
+{
+  "amt2abc": {
+    "id": "form-simple-input-submit",
+    "name": "简单输入表单 ABC",
+    "industry": "general",
+    "category": "form",
+    "author": "你的名字或团队",
+    "sanitized": true
+  },
+
+  ... 这里是你原来的内容 ...
+}
+```
+
+**字段怎么填：**
+
+| 字段 | 填什么 | 例子 |
+|------|--------|------|
+| `id` | 用英文，`类型-功能` 格式，别用中文别有空格 | `form-simple-input-submit` |
+| `name` | 中文名，随便起 | `简单输入表单 ABC` |
+| `industry` | 行业；通用的填 `general` | `die-casting` / `general` |
+| `category` | 类型 | `form` / `monitoring` / `control` |
+| `author` | 你的署名 | `zylliondata` |
+| `sanitized` | 你自查过了就填 `true` | `true` |
+
+> [!warning] 逗号别漏
+> `amt2abc` 这段结束后**必须有一个逗号**，否则 JSON 会报错。看上面的例子，`}` 后面有个 `,`。
+
+## 第 4 步：提交 PR（Pull Request）
+
+> [!info] 完全没用过 GitHub？
+> 先看最后一节「**新手：GitHub 三步速成**」，注册个账号再回来。
+
+1. 在 GitHub 上打开仓库网页版，点 `Add file` → `Create new file`
+2. 文件名填：`abc/general/<你的id>/abc.json`（比如 `abc/general/form-simple-input-submit/abc.json`）
+3. 把你的 JSON 内容粘进去
+4. 拉到最下面，点 `Propose new file` → `Create pull request`
+5. 等维护者审核。如果让你改，按提示改就行。
+
+完事。
+
+---
+
+## 新手：GitHub 三步速成
+
+> 只学够交 ABC 用的，3 分钟看完。
+
+**① 注册账号**
+访问 [github.com](https://github.com) → `Sign up` → 填邮箱密码。
+
+**② Fork 仓库**
+打开仓库页面 → 右上角点 `Fork` → `Create fork`。这等于把仓库复制一份到你自己的账号下。
+
+**③ 改文件 + 提 PR**
+在自己 fork 的页面点 `Add file` → `Create new file` → 填路径、粘内容 → 点两次绿色按钮提交 PR。
+
+> 维护者合并后，你的 ABC 就出现在开源仓库里了。
+
+---
+
+## 遇到问题
+
+- JSON 报错？多半是**逗号**漏了或多了一处，检查 `amt2abc` 段前后的逗号。
+- 不知道 `industry` / `category` 填啥？通用的都填 `general` / `form`，维护者会帮你调。
+- 其他问题：直接问维护者，或提一个 [Issue](https://github.com/zylliondata/AMT2ABC/issues)。
+
+---
+
+## 提完 PR 之后怎么办
+
+维护者会审核你的 PR。**核心一句话：让你改就在原来的分支上改，PR 会自动更新，不要新开 PR。**
+
+### 维护者的反馈 → 你要做什么
+
+| 维护者说 | 你做什么 |
+|----------|----------|
+| "脱敏漏了一处，把 XX 改掉" | 改那处 → 提交到**原分支** → PR 自动更新 |
+| "字段名不够语义化" | 改字段 → 提交到**原分支** |
+| "格式/逗号错了" | 修好 → 提交到**原分支** |
+| "OK，合并了" | 不用做事，完事 |
+
+### 怎么"提交到原分支"
+
+**方式 A：网页改（新手推荐）**
+
+1. 打开你的 PR 页面，点进文件
+2. 点右上角 ✏️ 铅笔图标编辑
+3. 改完点 `Commit changes`
+4. **分支名选你提 PR 的那个**（别选 `main`）
+5. 回到 PR 页面，会看到"已更新"
+
+**方式 B：git 命令（会用 git 的人）**
+
+```bash
+git checkout 你提PR的那个分支
+# 改文件
+git add .
+git commit -m "fix: 按审核意见修改"
+git push
+```
+
+push 完 PR 自动更新。
+
+### 三条心智模型
+
+1. **PR 绑定的是分支** —— 往那个分支 push 新提交，PR 就更新
+2. **永远不要新开 PR** 改同一个 ABC，一直在原来那个 PR 上改
+3. **改完不用通知维护者** —— PR 更新他们会自动收到提醒
+
+来回改几次很正常，改到维护者满意就合并，你的 ABC 就进开源仓库了。

--- a/docs/proposal-abc-pipeline.md
+++ b/docs/proposal-abc-pipeline.md
@@ -1,0 +1,89 @@
+# ABC 开源贡献流水线方案
+
+> 状态：草案
+> 作者：iAAB
+> 日期：2026-06-23
+
+## 1. 目标
+
+建立一条 ABC 贡献流水线，把团队产出的优质 ABC 经脱敏后沉淀为开源资产。
+
+## 2. 核心思路：分工
+
+为降低贡献门槛，流程按角色拆分。**贡献者只做最少的事，复杂度全部由维护者承担。**
+
+| | 贡献者（团队成员） | 维护者 |
+|---|---|---|
+| 做什么 | 导出 ABC → 粗查敏感信息 → 填 `amt2abc` 头 → 提 PR | 脱敏复核 → 规范校验 → 合并入库 |
+| 要懂 git/GitHub 吗 | 只要会"改文件 + 提 PR"两步（见快速指南） | 全套 |
+
+> 普通贡献者只需阅读 [`contribute-abc-quickstart.md`](./contribute-abc-quickstart.md)，按步骤照做即可。
+
+## 3. 仓库结构
+
+```
+abc/<industry>/<capability-slug>/
+  ├── abc.json          # 脱敏后的 ABC（amt2abc 头 + 原始 DSL）
+  ├── README.md         # 能力说明 + 脱敏记录
+  └── examples/         # 输入/输出示例
+abc-registry/index.json # ABC 索引（维护者维护）
+```
+
+- `<industry>`：行业/产线，如 `die-casting`；通用组件用 `general`
+- `<capability-slug>`：小写语义化，如 `form-simple-input-submit`
+
+## 4. ABC 结构
+
+ABC 是一段可运行的低代码 Module DSL，提交时在最外层包一个 `amt2abc` 元信息头：
+
+```
+abc.json = {
+  "amt2abc": { ... },          ← 贡献者填（见下）
+  "applicationInfo": { ... },  ← 原始模块元数据
+  "applicationDSL": { ... }    ← 原始可运行定义
+}
+```
+
+`amt2abc` 头字段（**贡献者必填**）：
+
+| 字段 | 说明 | 示例 |
+|------|------|------|
+| `id` | 全局唯一，`<category>-<slug>` | `form-simple-input-submit` |
+| `name` | 中文名 | `简单输入表单 ABC` |
+| `industry` | 行业/产线 | `die-casting` / `general` |
+| `category` | 能力类型 | `form` / `monitoring` / `control` |
+| `author` | 署名 | `zylliondata` |
+| `sanitized` | 是否已自查脱敏 | `true` |
+
+> 完整字段与 Schema 规范见 [`abc-spec.md`](./abc-spec.md)（维护者参考）。
+
+## 5. 提交流程
+
+```mermaid
+graph TD
+    A[导出 ABC JSON] --> B[粗查敏感信息]
+    B --> C[填 amt2abc 头]
+    C --> D[提 PR]
+    D --> E{维护者复核}
+    E -->|脱敏/规范问题| A
+    E -->|通过| F[合并入库]
+```
+
+**贡献者四步**：导出 → 粗查 → 填头 → 提 PR。详见快速指南。
+
+**维护者**：复核脱敏 → 校验规范 → 合并 → 更新 `abc-registry/index.json`。
+
+## 6. 脱敏原则
+
+脱敏是 ABC 进仓库的**前置必要条件**。
+
+- **贡献者**：导出后粗查，确保无客户名、IP、真实字段名、人名等。
+- **维护者**：逐字段复核，重点 `inputs/outputs/methods/event/global/ui`，任何疑似泄露一律打回。
+
+> 任何脱敏遗漏导致信息泄露，责任由提交者承担。
+
+## 7. 相关文档
+
+- [`contribute-abc-quickstart.md`](./contribute-abc-quickstart.md) — 贡献者快速指南（普通用户看这个）
+- [`abc-spec.md`](./abc-spec.md) — ABC 完整规范（维护者参考）
+- [`desensitization-guide.md`](./desensitization-guide.md) — 脱敏详细指南（维护者参考）


### PR DESCRIPTION
作为 AMT2ABC 的第一个标杆 ABC,演示完整的脱敏 + 入库流程。

## 内容
- **标杆范例 ABC**:标题 + 输入框 + 提交/取消 表单 Module
- 暴露 `inputValue` / `isSubmitted` 输出,`onSubmit` / `onCancel` 事件
- 配套 `README.md`(接口契约 + 脱敏记录)与 `examples/`(输入/输出示例)
- 新增 `docs/` 贡献指南(`contribute-abc-quickstart.md`)与流水线方案(`proposal-abc-pipeline.md`)
- 添加 `.gitignore` 排除 Windows `nul` 误生成文件

## 脱敏自查
`amt2abc.sanitized = true`,处理项:
- `applicationInfo.id` → `000000000000000000000000`
- `applicationInfo.name` → 语义化 `simple-input-form`
- 时间戳/创建者已清零
- 全量扫描无 IP / 客户名 / 真实字段名

## 检查清单
- [x] `amt2abc` 头 6 字段齐全
- [x] 路径符合 `abc/<industry>/<capability-slug>/abc.json` 约定
- [x] 配套 README + examples
- [x] JSON 合法
- [x] 脱敏自查通过